### PR TITLE
Adjusting HTML title

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -142,7 +142,7 @@ html_context = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = 'Netris 2.9 Documentation'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
This changes "Netris docs Netris v2.9 documentation" to "Netris v2.9 documentation" in HTML title.