### PR TITLE
Mark Arista as supported. Minor linting.

### DIFF
--- a/supported-switch-hardware.rst
+++ b/supported-switch-hardware.rst
@@ -7,7 +7,7 @@ Netris Controller
 
 We recommend three (for HA) Ubuntu 24.04 servers with the below specs. HA Netris Controller can run both in air-gapped or Internet accessible environments.
 
-.. list-table:: 
+.. list-table::
    :header-rows: 0
 
    * - **Use Case**
@@ -58,10 +58,10 @@ A minimum of 4 dedicated servers are required for an HA (highly available) activ
 
 Server specs:
 
-.. list-table:: 
+.. list-table::
    :header-rows: 0
 
-   * - 
+   * -
      - **Minimum**
      - **Recommended**
    * - CPU (Modern Intel/AMD X86)
@@ -91,7 +91,7 @@ Supported Switch Hardware
 
 Nvidia
 ======
-.. list-table:: 
+.. list-table::
    :header-rows: 0
 
    * - **Manufacturer**
@@ -106,98 +106,98 @@ Nvidia
      - Spectrum
      - 18 x SFP28 25GbE + 4 x QSFP28 100GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN2100
      - Spectrum
      - 16 x QSFP28 100GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN2201
      - Spectrum
      - 48 x RJ45 + 4 x QSFP28 100GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN2410
      - Spectrum
      - 48 x SFP28 25GbE + 8 x QSFP28 100GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN2700
      - Spectrum
      - 32 x QSFP28 100GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN3420
      - Spectrum 2
      - 48 x SFP28 25GbE + 12 x QSFP28 100GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN3700C
      - Spectrum 2
      - 32 x QSFP28 100GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN3700
      - Spectrum 2
      - 32 x QSFP56 200GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN4410
      - Spectrum 3
      - 24 x QSFP28-DD 100G + 8 x QSFP-DD 400GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN4600C
      - Spectrum 3
      - 64 x QSFP28 100GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN4600
      - Spectrum 3
      - 64 QSFP56 200GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN4700
      - Spectrum 3
      - 32 x QSFP-DD 400GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN5400
      - Spectrum 4
      - 64 x QSFP-DD 400GbE + 2 x SFP28 25GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
    * - Nvidia
      - SN5600
      - Spectrum 4
      - 64 x OSFP 800GbE + 1 x SFP28 25GbE
      - Cumulus Linux
-     - 
+     -
      - ✔
 
 
@@ -356,7 +356,7 @@ Dell
 
 EdgeCore
 ========
-.. list-table:: 
+.. list-table::
    :header-rows: 0
 
    * - **Manufacturer**
@@ -371,54 +371,54 @@ EdgeCore
      - Broadcom Trident III
      - 48 x 10G SFP+ + 6 x 100G QSFP28
      - EC-SONiC
-     - 
+     -
      - ✔
    * - EdgeCore
      - DCS202 (AS5835-54T)
      - Broadcom Trident III
      - 48 x 10G RJ-45 + 6 x 100G QSFP28
      - EC-SONiC
-     - 
+     -
      - ✔
    * - EdgeCore
      - DCS203 (AS7326-56X)
      - Broadcom Trident III
      - 48 x 25G SFP28 + 8 x 100G QSFP28+ 2 x 10G
      - EC-SONiC
-     - 
+     -
      - ✔
    * - EdgeCore
      - AS7726-32X
      - Broadcom Trident III
      - 32 x 100G QSFP28 + 2 x 10G SFP+
      - EC-SONiC
-     - 
+     -
      - ✔
    * - EdgeCore
      - DCS510 (AS9716-32D)
      - Broadcom Tomahawk 3
-     - 32 x 400G QSFP-DD 
+     - 32 x 400G QSFP-DD
      - EC-SONiC
-     - 
+     -
      - ✔
    * - EdgeCore
      - DCS511 (AS9737-32DB)
      - Broadcom Tomahawk 4
      - 32 x 400G QSFP56-DD
      - EC-SONiC
-     - 
+     -
      - ✔
    * - EdgeCore
      - AIS800-64O
      - Broadcom Tomahawk 5
      - 64 x OSFP800
      - EC-SONiC
-     - 
+     -
      - ✔
 
 Arista
 ========
-.. list-table:: 
+.. list-table::
    :header-rows: 0
 
    * - **Manufacturer**
@@ -433,82 +433,82 @@ Arista
      - Qumran
      - 24 x 10G + 2 QSFP100; 32 x 10G + 2 QSFP100; 48 x 100/1000Mb + 6 SFP+; 48 x 100/1000Mb + 6 SFP+
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7050X3
      - Broadcom Trident III
      - 32 x QSFP100; 48 x SFP25 + 12 x QSFP100; 48 x SFP25 + 8 x QSFP100; 48 x 10G-T + 8 x QSFP100
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7050X4
      - Trident-4
      - 32 QSFP-DD 400G + 2SFP+; 32 OSFP 400G + 2SFP+; 48 SFP-DD 100G + 8 QSFP-DD 400G; 48 DSFP 100G + 8 QSFPDD 400G; 24 QSFP56 200G + 8 QSFPDD 400G + 2SFP+; 48 QSFP28 + 8 QSFP-DD 400G + 2SFP+
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7060X4
      - Trident-4
      - 32 x QSFP-DD 800G + 2 x SFP+; 32 x QSFP-DD 800G + 2 x SFP+; 32 x OSFP 800G + 2 x SFP+; 64 x QSFP-DD 400G, 2 x SFP+; 32 x QSFP-DD + 1x SFP+; 56x QSFP100, 8 x QSFP-DD 400G + 1x SFP+
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7060X5
      - Tomahawk 4
      - 32 x QSFP-DD 800G + 2x SFP+; 32 x QSFP-DD 800G + 2x SFP+; 32 x OSFP 800G + 2x SFP+; 64 x QSFP-DD 400G + 2x SFP+; : 32 x QSFP-DD + 1 x SFP+; 56x QSFP100, 8 x QSFP-DD 400G, 1x SFP+
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7280R3A
      - Jericho2
-     - 144 x 100G or 36 x 400G 
+     - 144 x 100G or 36 x 400G
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7280R3
      - Jericho2
      - 24 x 400G; 96 x 100G; 25G + 8 x 100G
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7358X4
      - Trident-4
      - 128 x QSFP or 32 x OSFP / QSFP-DD
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7358X4
      - Trident-4
      - 128 x QSFP or 32 x OSFP / QSFP-DD
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7368X4
      - Tomahawk 3
      - 128 x 100G or 32 x 400G
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7300R3
      - Trident-4
-     - 256 wire-speed 40GbE ports 
+     - 256 wire-speed 40GbE ports
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔
    * - Arista
      - 7500R3
      - Jericho, Jericho2
      - Up to 288 wire-speed 400G ports
      - EOS
-     - 
-     - Dec/2024
+     -
+     - ✔


### PR DESCRIPTION
Marked all Arista models as fully supported. Changed from "planned support in Dec/2024".
Performed minor linting, removing rogue white spaces.